### PR TITLE
Update build setup for new cheat sheet structure

### DIFF
--- a/.github/workflows/deploy_cheat_sheets.yaml
+++ b/.github/workflows/deploy_cheat_sheets.yaml
@@ -11,7 +11,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'source/cheatsheet*.rst'
+      - 'source/**/*.rst'
 
 jobs:
   Deploy_cheat_sheets:

--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,12 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SPHINXPROJECT ?= phytec-cheatsheets
-RST2PDFBUILD  ?= rst2pdf
-RST2PDFOPTS   ?=
 SOURCEDIR     = source
 BUILDDIR      = build
-CHEATSHEETS   = cheatsheet_uboot.pdf cheatsheet_linux.pdf cheatsheet_yocto.pdf
 
-# Build all cheat sheets as separate pdf 
-pdf: $(CHEATSHEETS)
-
-%.pdf: $(SOURCEDIR)/%.rst | $(BUILDDIR)
-	$(RST2PDFBUILD) $(RST2PDFOPTS) $+ -o $(BUILDDIR)/$@
-
-# Build all cheatsheets a single pdf
-pdf_full: | $(BUILDDIR) 
-	$(SPHINXBUILD) -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
-	cp $(BUILDDIR)/latex/$(SPHINXPROJECT).pdf $(BUILDDIR)/$(SPHINXPROJECT)_full.pdf
+# Build all cheat sheets as separate pdf files 
+pdf: | $(BUILDDIR)
+	$(SPHINXBUILD) -b pdf "$(SOURCEDIR)" "$(BUILDDIR)"
 
 # Create full HTML version of the cheat sheets
 html: | $(BUILDDIR)
@@ -30,7 +20,6 @@ html: | $(BUILDDIR)
 # Create build directory
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
-	
 
 clean:
 	rm -rf $(BUILDDIR)

--- a/README.rst
+++ b/README.rst
@@ -73,20 +73,11 @@ Start coding
 Build the Documentation
 #######################
 
-Build the separate cheat sheets:
+Build the cheat sheets as PDF-files:
 
 .. code-block:: text
+
    make pdf
-
-Build the whole documentation and generate a single PDF document.
-
-.. code-block:: text
-
-   make pdf_full
-
-- On Ubuntu 20.04 you need to install some latex packages, e.g.::
-
-        apt install texlive texlive-latex-extra latexmk
 
 Build the documentation and generate html format.
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -23,15 +23,14 @@ author = 'Phytec i.MX8-Team'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1'
-
+version = '0.1'
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-#  extensions = [
-#  ]
+extensions = ['sphinx.ext.autodoc','rst2pdf.pdfbuilder']
 
 # Add any paths that contain templates here, relative to this directory.
 #  templates_path = ['_templates']
@@ -56,7 +55,11 @@ html_theme = 'sphinx_rtd_theme'
 
 
 # -- Options for PDF output -------------------------------------------------
-latex_elements = {
-    'fontpkg': '\\usepackage{lmodern}'
-}
+pdf_documents = [
+    ('index', u'cheatsheets_full', u'PHYTEC Cheatsheets', u'Phytec i.MX8 Team', {}),
+    ('cheatsheet_linux', u'cheatsheet_linux', u'PHYTEC Cheatsheet Linux', u'Phytec i.MX8 Team', {}),
+    ('cheatsheet_uboot', u'cheatsheet_uboot', u'PHYTEC Cheatsheet Uboot', u'Phytec i.MX8 Team', {}),
+    ('cheatsheet_yocto', u'cheatsheet_yocto', u'PHYTEC Cheatsheet Yocto', u'Phytec i.MX8 Team', {})]
 
+pdf_toc_depth = 2
+pdf_blank_first_page = False

--- a/source/index.rst
+++ b/source/index.rst
@@ -10,11 +10,3 @@ for new and advanced users of PHYTEC SOMs and SBCs.
    cheatsheet_linux
    cheatsheet_uboot
    cheatsheet_yocto
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
Sice we changed our file structure for the cheats heets, we needed to update the build system:

- include RST2PDF in sphinx-build, for better PDF file generation and remove the LaTex dependency
- update Makefile for new build setup
- update build action to trigger on all changes of RST-files
- update README.md
- remove unused section in index.rst

Signed-off-by: Jonas Kuenstler <j.kuenstler@phytec.de>